### PR TITLE
Support older apache httpclient libs

### DIFF
--- a/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRoutePlanner.java
+++ b/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRoutePlanner.java
@@ -32,7 +32,7 @@ public class ApacheHttpClientEdgeGridRoutePlanner extends DefaultRoutePlanner {
     public HttpRoute determineRoute(HttpHost host, HttpRequest request, HttpContext context) throws HttpException {
         try {
             ClientCredential clientCredential = binding.getClientCredentialProvider().getClientCredential(binding.map(request));
-            HttpHost target = HttpHost.create("https://" + clientCredential.getHost());
+            HttpHost target = new HttpHost(clientCredential.getHost(), -1, "https");
             return super.determineRoute(target, request, context);
         } catch (NoMatchingCredentialException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
The `HttpHost.create` method was introduced in apache httpclient 4.4. This change should make the lib compatible with older versions of httpclient and still maintain forward compatibility.