### PR TITLE
#29 Add bindings for Async HTTP Client (AHC) and Gatling. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,20 @@ libraries.
 
 ## Modules
 
-This project contains a core implementation module and three bindings to specific HTTP client libraries.
+This project contains a core implementation module and five bindings to specific HTTP client libraries.
 
 * [edgegrid-signer-core](edgegrid-signer-core) is the core signing implementation and base classes used by the individual library implementations.
-* [edgegrid-signer-apache-http-client](edgegrid-signer-apache-http-client) is a binding for [Apache HTTP Client][2]
-* [edgegrid-signer-google-http-client](edgegrid-signer-google-http-client) is a binding for [Google HTTP Client Library for Java][3]
+* [edgegrid-signer-apache-http-client](edgegrid-signer-apache-http-client) is a binding for [Apache HTTP Client][2].
+* [edgegrid-signer-google-http-client](edgegrid-signer-google-http-client) is a binding for [Google HTTP Client Library for Java][3].
 * [edgegrid-signer-rest-assured](edgegrid-signer-rest-assured) is a binding for [REST-assured][4].
+* [edgegrid-signer-async-http-client](edgegrid-signer-async-http-client) is a binding for [Async HTTP Client][13].
+* [edgegrid-signer-gatling](edgegrid-signer-gatling) is a binding for [Gatling][14].
 
 ## Changes
+
+3.0:
+- Adding binding for Async HTTP Client.
+- Adding binding for Gatling.
 
 2.1:
 - Adding binding for Apache HTTP Client.
@@ -32,10 +38,10 @@ This project contains a core implementation module and three bindings to specifi
 
 2.0:
 - Signing algorithm tweaks
-- Separated binding for Google HTTP Client Library for Java from core
-- Added binding for REST-assured
+- Separating binding for Google HTTP Client Library for Java from core
+- Adding binding for REST-assured
 - Unit tests with TestNG
-- Published to Maven Central!
+- Publishing to Maven Central!
 
 ## Similar tools
 
@@ -62,6 +68,8 @@ programming languages:
 [10]: https://github.com/akamai-open/AkamaiOPEN-edgegrid-node
 [11]: https://github.com/akamai-open/AkamaiOPEN-edgegrid-C-Sharp
 [12]: https://github.com/akamai-open/AkamaiOPEN-edgegrid-golang
+[13]: https://github.com/AsyncHttpClient/async-http-client
+[14]: https://gatling.io/
 
 ## Authors
 

--- a/edgegrid-signer-apache-http-client/README.md
+++ b/edgegrid-signer-apache-http-client/README.md
@@ -11,7 +11,7 @@ Java implementation of Akamai {OPEN} EdgeGrid signing.
 ## Description
 
 This library implements [Akamai {OPEN} EdgeGrid Authentication][1] for Java.
-This particular module is a binding the the [Apache HTTP Client library][2].
+This particular module is a binding for the [Apache HTTP Client library][2].
 
 ## Usage of Apache HTTP Client
 
@@ -21,7 +21,7 @@ Include the following Maven dependency in your project POM:
 <dependency>
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-apache-http-client</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>2.1.1</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridInterceptor.java
+++ b/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridInterceptor.java
@@ -47,7 +47,7 @@ public class ApacheHttpClientEdgeGridInterceptor implements HttpRequestIntercept
     @Override
     public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
         try {
-            binding.sign(request);
+            binding.sign(request, request);
         } catch (RequestSigningException e) {
             throw new RuntimeException(e);
         }

--- a/edgegrid-signer-apache-http-client/src/test/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridInterceptorIntegrationTest.java
+++ b/edgegrid-signer-apache-http-client/src/test/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridInterceptorIntegrationTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
 
 
 /**
- * Integration tests for {@link com.akamai.edgegrid.signer.apachehttpclient.ApacheHttpClientEdgeGridInterceptor}.
+ * Integration tests for {@link ApacheHttpClientEdgeGridInterceptor}.
  *
  * @author mgawinec@akamai.com
  * @author mmeyer@akamai.com

--- a/edgegrid-signer-apache-http-client/src/test/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRequestSignerTest.java
+++ b/edgegrid-signer-apache-http-client/src/test/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRequestSignerTest.java
@@ -57,7 +57,7 @@ public class ApacheHttpClientEdgeGridRequestSignerTest {
         HttpRequest request = new HttpGet("https://ignored-hostname.com/billing-usage/v1/reportSources");
 
         ApacheHttpClientEdgeGridRequestSigner apacheHttpSinger = new ApacheHttpClientEdgeGridRequestSigner(credential);
-        apacheHttpSinger.sign(request);
+        apacheHttpSinger.sign(request, request);
 
 
         assertThat(URI.create(request.getRequestLine().getUri()).getHost(), equalTo("endpoint.net"));

--- a/edgegrid-signer-async-http-client/README.md
+++ b/edgegrid-signer-async-http-client/README.md
@@ -1,0 +1,65 @@
+# EdgeGrid Client for Java
+
+Java implementation of Akamai {OPEN} EdgeGrid signing.
+
+[![Build Status](https://travis-ci.org/akamai-open/AkamaiOPEN-edgegrid-java.svg?branch=master)](https://travis-ci.org/akamai-open/AkamaiOPEN-edgegrid-java)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.akamai.edgegrid/edgegrid-signer-async-http-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.akamai.edgegrid/edgegrid-signer-async-http-client)
+[![Reference Status](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-async-http-client/reference_badge.svg?style=flat-square)](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-async-http-client/references)
+[![Dependency Status](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-async-http-client/badge?style=flat-square)](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-async-http-client)
+[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.akamai.edgegrid/edgegrid-signer-async-http-client/badge.svg)](http://www.javadoc.io/doc/com.akamai.edgegrid/edgegrid-signer-async-http-client)
+
+## Description
+
+This library implements [Akamai {OPEN} EdgeGrid Authentication][1] for Java.
+This particular module is a binding for the [Async HTTP Client library][2].
+
+## Usage of Async HTTP Client
+
+Include the following Maven dependency in your project POM:
+
+```xml
+<dependency>
+    <groupId>com.akamai.edgegrid</groupId>
+    <artifactId>edgegrid-signer-async-http-client</artifactId>
+    <version>3.0.0</version>
+</dependency>
+```
+
+Create an HTTP request that will be signed with a defined client credential:
+
+```java
+Request request = new RequestBuilder("POST")
+    .setUrl("https://localhost/papi/v0/properties")
+    .addQueryParam("contractId","ctr_1-3CV382")
+    .addQueryParam("groupId","grp_18385")
+    .setBody("{ \"productId\": \"Site_Accel\", \"propertyName\": \"8LuWyUjwea\" }")
+    .setHeader("Content-Type", "application/json")
+    .setSignatureCalculator(new AsyncHttpClientEdgeGridSignatureCalculator(clientCredential))
+    .build();
+
+asyncHttpClient().executeRequest(request).get();
+```
+
+Alternatively, create an HTTP client that will sign each HTTP request with a defined client 
+credential:
+
+```java
+AsyncHttpClient client = asyncHttpClient()
+    .setSignatureCalculator(new AsyncHttpClientEdgeGridSignatureCalculator(clientCredential));
+
+client.preparePost("https://localhost/papi/v0/properties")
+    .addQueryParam("contractId","ctr_1-3CV382")
+    .addQueryParam("groupId","grp_18385")
+    .setBody("{ \"productId\": \"Site_Accel\", \"propertyName\": \"8LuWyUjwea\" }")
+    .setHeader("Content-Type", "application/json")
+    .execute().get();
+```
+
+Note, in the latter case requests *must* be prepared with the HTTP client.
+
+Note, in both cases the host part of the URI does not matter, because it will be replaced by
+the provided `AsyncHttpClientEdgeGridSignatureCalculator`  with the host from the provided client 
+credential.
+
+[1]: https://developer.akamai.com/introduction/Client_Auth.html
+[2]: https://github.com/AsyncHttpClient/async-http-client

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>edgegrid-signer-parent</artifactId>
+        <groupId>com.akamai.edgegrid</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>edgegrid-signer-async-http-client</artifactId>
+    <packaging>jar</packaging>
+    <name>Asynchronous HTTP Client binding for EdgeGrid Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.akamai.edgegrid</groupId>
+            <artifactId>edgegrid-signer-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSigner.java
+++ b/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSigner.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akamai.edgegrid.signer.ahc;
+
+import com.google.common.primitives.Bytes;
+
+import com.akamai.edgegrid.signer.AbstractEdgeGridRequestSigner;
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.ClientCredentialProvider;
+
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilderBase;
+import org.asynchttpclient.request.body.generator.FileBodyGenerator;
+import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator;
+import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
+import org.asynchttpclient.uri.Uri;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.asynchttpclient.util.MiscUtils.isNonEmpty;
+
+public class AsyncHttpClientEdgeGridRequestSigner extends AbstractEdgeGridRequestSigner<Request, RequestBuilderBase> {
+
+    public AsyncHttpClientEdgeGridRequestSigner(ClientCredential credential) {
+        super(credential);
+    }
+
+    public AsyncHttpClientEdgeGridRequestSigner(ClientCredentialProvider credentialProvider) {
+        super(credentialProvider);
+    }
+
+    @Override
+    protected URI requestUri(Request request) {
+        try {
+            return request.getUri().toJavaNetURI();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected com.akamai.edgegrid.signer.Request map(Request request) {
+
+        com.akamai.edgegrid.signer.Request.RequestBuilder builder = com.akamai.edgegrid.signer.Request.builder()
+            .uri(request.getUrl())
+            .method(request.getMethod())
+            .body(serializeBody(request));
+
+        for (Map.Entry<String, String> e : request.getHeaders().entries()) {
+            builder.header(e.getKey(), e.getValue());
+        }
+
+        return builder.build();
+    }
+
+    private byte[] serializeBody(Request request) {
+
+        if (request.getByteData() != null) {
+            return request.getByteData();
+        } else if (request.getCompositeByteData() != null) {
+            List<Byte> buff = new ArrayList<>();
+            for (byte[] bytes : request.getCompositeByteData()) {
+                buff.addAll(Bytes.asList(bytes)); // Without Guava that would be quite cumbersome
+            }
+            return Bytes.toArray(buff);
+        } else if (request.getStringData() != null) {
+            return request.getStringData().getBytes();
+        } else if (request.getByteBufferData() != null) {
+            throw new UnsupportedOperationException("Serializing ByteBufferData in request body is not supported");
+        } else if (request.getStreamData() != null) {
+            throw new UnsupportedOperationException("Serializing StreamData in request body is not supported");
+        } else if (isNonEmpty(request.getFormParams())) {
+            throw new UnsupportedOperationException("Serializing FormParams in request body is not supported");
+        } else if (isNonEmpty(request.getBodyParts())) {
+            throw new UnsupportedOperationException("Serializing BodyParts in request body is not supported");
+        } else if (request.getFile() != null) {
+            throw new UnsupportedOperationException("Serializing File in request body is not supported");
+        } else if (request.getBodyGenerator() instanceof FileBodyGenerator) {
+            throw new UnsupportedOperationException("Serializing FileBodyGenerator in request body is not supported");
+        } else if (request.getBodyGenerator() instanceof InputStreamBodyGenerator) {
+            throw new UnsupportedOperationException("Serializing InputStreamBodyGenerator in request body is not supported");
+        } else if (request.getBodyGenerator() instanceof ReactiveStreamsBodyGenerator) {
+            throw new UnsupportedOperationException("Serializing ReactiveStreamsBodyGenerator in request body is not supported");
+        } else if (request.getBodyGenerator() != null) {
+            throw new UnsupportedOperationException("Serializing generic BodyGenerator in request body is not supported");
+        } else {
+            return new byte[]{};
+        }
+    }
+
+
+    @Override
+    protected void setAuthorization(RequestBuilderBase requestToUpdate, String signature) {
+        requestToUpdate.setHeader("Authorization", signature);
+    }
+
+    @Override
+    protected void setHost(RequestBuilderBase requestToUpdate, String host, URI uri) {
+        requestToUpdate.setHeader("Host", host);
+        // uri already contains query params that existed in original query
+        requestToUpdate.resetQuery();
+        requestToUpdate.setUri(toAsyncHttpClientUri(uri));
+    }
+
+    private static Uri toAsyncHttpClientUri(URI uri) {
+        return Uri.create(uri.toString());
+    }
+
+}

--- a/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSigner.java
+++ b/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculator.java
+++ b/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akamai.edgegrid.signer.ahc;
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.ClientCredentialProvider;
+import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
+
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilderBase;
+import org.asynchttpclient.SignatureCalculator;
+
+public class AsyncHttpClientEdgeGridSignatureCalculator implements SignatureCalculator {
+
+    private final AsyncHttpClientEdgeGridRequestSigner binding;
+
+    public AsyncHttpClientEdgeGridSignatureCalculator(ClientCredential credential) {
+        this.binding = new AsyncHttpClientEdgeGridRequestSigner(credential);
+    }
+
+    public AsyncHttpClientEdgeGridSignatureCalculator(ClientCredentialProvider credentialProvider) {
+        this.binding = new AsyncHttpClientEdgeGridRequestSigner(credentialProvider);
+    }
+
+    @Override
+    public void calculateAndAddSignature(Request request, RequestBuilderBase<?> requestToUpdate) {
+        try {
+            binding.sign(request, requestToUpdate);
+        } catch (RequestSigningException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculator.java
+++ b/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSignerIntegrationTest.java
+++ b/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSignerIntegrationTest.java
@@ -1,0 +1,85 @@
+package com.akamai.edgegrid.signer.ahc;
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.Response;
+import org.hamcrest.CoreMatchers;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.concurrent.ExecutionException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AsyncHttpClientEdgeGridRequestSignerIntegrationTest {
+
+    static final String SERVICE_MOCK_HOST = "localhost";
+    static final int SERVICE_MOCK_PORT = 9089;
+    static final String SERVICE_MOCK = SERVICE_MOCK_HOST + ":" + SERVICE_MOCK_PORT;
+
+    ClientCredential credential = ClientCredential.builder()
+        .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+        .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+        .clientSecret("SOMESECRET")
+        .host(SERVICE_MOCK)
+        .build();
+
+    WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(SERVICE_MOCK_PORT));
+
+    @BeforeClass
+    public void setUp() {
+        wireMockServer.start();
+    }
+
+    @BeforeMethod
+    public void reset() {
+        wireMockServer.resetMappings();
+        wireMockServer.resetRequests();
+    }
+
+    @Test
+    public void signEachRequest() throws URISyntaxException, IOException, ExecutionException, InterruptedException {
+
+        wireMockServer.stubFor(post(urlPathEqualTo("/papi/v0/properties"))
+            .withHeader("Authorization", matching(".*"))
+            .withHeader("Host", equalTo(SERVICE_MOCK))
+            .willReturn(aResponse()
+                .withStatus(201)
+                .withHeader("Content-Type", "text/xml")
+                .withBody("<response>Some content</response>")));
+
+        Request request = new RequestBuilder("POST")
+            .setUrl("http://" + credential.getHost() + "/papi/v0/properties")
+            .addQueryParam("contractId","ctr_1-3CV382")
+            .addQueryParam("groupId","grp_18385")
+            .setBody("{ \"productId\": \"Site_Accel\", \"propertyName\": \"8LuWyUjwea\" }")
+            .setHeader("Content-Type", "application/json")
+            .setSignatureCalculator(new AsyncHttpClientEdgeGridSignatureCalculator(credential))
+            .build();
+
+        asyncHttpClient().executeRequest(request).get();
+
+        assertThat(wireMockServer.findAllUnmatchedRequests().size(), CoreMatchers.equalTo(0));
+    }
+
+    @AfterClass
+    public void tearDownAll() {
+        wireMockServer.stop();
+    }
+}

--- a/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSignerIntegrationTest.java
+++ b/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSignerIntegrationTest.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.akamai.edgegrid.signer.ahc;
 
 import com.akamai.edgegrid.signer.ClientCredential;
 import com.github.tomakehurst.wiremock.WireMockServer;
 
-import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilder;
-import org.asynchttpclient.Response;
 import org.hamcrest.CoreMatchers;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -19,7 +33,6 @@ import java.util.concurrent.ExecutionException;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;

--- a/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculatorTest.java
+++ b/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculatorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akamai.edgegrid.signer.ahc;
+
+
+import com.akamai.edgegrid.signer.ClientCredential;
+
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+
+
+public class AsyncHttpClientEdgeGridSignatureCalculatorTest {
+
+    @Test(dataProvider = "requests")
+    public void testCalculateAndAddSignatureForGet(Request request) throws Exception {
+
+        ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host("endpoint.net")
+            .build();
+
+        RequestBuilder requestToUpdate = new RequestBuilder(request);
+        new AsyncHttpClientEdgeGridSignatureCalculator(credential).calculateAndAddSignature(
+            request, requestToUpdate);
+        Request updatedRequest = requestToUpdate.build();
+
+        assertThat(updatedRequest.getHeaders().get("Authorization"), not(isEmptyOrNullString()));
+        assertThat(updatedRequest.getHeaders().get("Host"), equalTo("endpoint.net"));
+        assertThat(updatedRequest.getUri().getHost(), equalTo("endpoint.net"));
+
+    }
+
+    @Test
+    public void testPreservingQueryString() throws Exception {
+
+        ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host("endpoint.net")
+            .build();
+
+        Request request = new RequestBuilder().setUrl("http://localhost/test?x=y").build();
+        RequestBuilder requestToUpdate = new RequestBuilder(request);
+
+        new AsyncHttpClientEdgeGridSignatureCalculator(credential).calculateAndAddSignature(
+            request, requestToUpdate);
+        Request updatedRequest = requestToUpdate.build();
+
+        assertThat(updatedRequest.getUri().getQuery(), equalTo("x=y"));
+
+    }
+
+    @Test
+    public void testNotDuplicatingQueryString() throws Exception {
+
+        ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host("endpoint.net")
+            .build();
+
+        Request request = new RequestBuilder().setUrl("http://localhost/test").addQueryParam("x", "y").build();
+        RequestBuilder requestToUpdate = new RequestBuilder(request);
+
+        new AsyncHttpClientEdgeGridSignatureCalculator(credential).calculateAndAddSignature(
+            request, requestToUpdate);
+        Request updatedRequest = requestToUpdate.build();
+
+        assertThat(updatedRequest.getUri().getQuery(), equalTo("x=y"));
+
+    }
+
+    @DataProvider
+    public Object[][] requests() {
+        return new Object[][]{
+            {new RequestBuilder().setUrl("http://localhost/test").build()},
+            {new RequestBuilder("POST").setUrl("http://localhost/test").setBody("content").build()},
+            {new RequestBuilder("POST").setUrl("http://localhost/test").setBody("content".getBytes()).build()},
+            {new RequestBuilder("POST").setUrl("http://localhost/test").setBody(Arrays.asList("content".getBytes())).build()}
+        };
+    }
+}

--- a/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculatorTest.java
+++ b/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 package com.akamai.edgegrid.signer.ahc;
-
 
 import com.akamai.edgegrid.signer.ClientCredential;
 

--- a/edgegrid-signer-async-http-client/src/test/resources/resources/logback-test.xml
+++ b/edgegrid-signer-async-http-client/src/test/resources/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="TRACE">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>2.1.1</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-gatling/README.md
+++ b/edgegrid-signer-gatling/README.md
@@ -1,0 +1,67 @@
+# EdgeGrid Client for Java
+
+Java implementation of Akamai {OPEN} EdgeGrid signing.
+
+[![Build Status](https://travis-ci.org/akamai-open/AkamaiOPEN-edgegrid-java.svg?branch=master)](https://travis-ci.org/akamai-open/AkamaiOPEN-edgegrid-java)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.akamai.edgegrid/edgegrid-signer-gatling/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.akamai.edgegrid/edgegrid-signer-gatling)
+[![Reference Status](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-gatling/reference_badge.svg?style=flat-square)](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-gatling/references)
+[![Dependency Status](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-gatling/badge?style=flat-square)](https://www.versioneye.com/java/com.akamai.edgegrid:edgegrid-signer-gatling)
+[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.akamai.edgegrid/edgegrid-signer-gatling/badge.svg)](http://www.javadoc.io/doc/com.akamai.edgegrid/edgegrid-signer-gatling)
+
+## Description
+
+This library implements [Akamai {OPEN} EdgeGrid Authentication][1] for Java.
+This particular module is a binding for the [Gatling][2].
+
+## Usage of Gatling
+
+Include the following Maven dependency in your project POM:
+
+```xml
+<dependency>
+    <groupId>com.akamai.edgegrid</groupId>
+    <artifactId>edgegrid-signer-gatling</artifactId>
+    <version>3.0.0</version>
+</dependency>
+```
+
+Create a Gatling simulation that inherits from `OpenApiSimulation` and is constructed with a defined
+client credential:
+
+```scala
+class YourSimulation extends OpenApiSimulation(clientCredential) {
+
+  ...
+
+ val testScenario = scenario("Test scenario")
+    .exec(
+      http("createPropertyRequest")
+        .post("/papi/v0/properties/")
+        .queryParam("contractId", "ctr_1-3CV382")
+        .queryParam("groupId", "grp_18385")
+        .body(StringBody(
+          """{
+                "productId": "Site_Accel",
+                "propertyName": "8LuWyUjwea"
+             }"""))
+        .asJSON
+        .check(status.is(201))
+    )
+
+  setUp(
+    testScenario.inject(atOnceUsers(1))
+  ).protocols(httpConf)
+
+}
+```
+
+Note, `httpConf` is a protocol configured to use the defined `clientCredential`.
+
+The binding works only with Gatling 2. It will not work Gatling 3.
+
+
+
+
+
+[1]: https://developer.akamai.com/introduction/Client_Auth.html
+[2]: https://gatling.io/

--- a/edgegrid-signer-gatling/pom.xml
+++ b/edgegrid-signer-gatling/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>edgegrid-signer-parent</artifactId>
+        <groupId>com.akamai.edgegrid</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>edgegrid-signer-gatling</artifactId>
+    <packaging>jar</packaging>
+    <name>Gatling binding for EdgeGrid Client</name>
+
+    <properties>
+        <gatling-plugin.version>2.2.4</gatling-plugin.version>
+        <scala-maven-plugin.version>3.3.2</scala-maven-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.akamai.edgegrid</groupId>
+            <artifactId>edgegrid-signer-async-http-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gatling</groupId>
+            <artifactId>gatling-app</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.gatling.highcharts</groupId>
+            <artifactId>gatling-charts-highcharts</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-maven-plugin</artifactId>
+                <version>${gatling-plugin.version}</version>
+                <configuration>
+                    <runMultipleSimulations>true</runMultipleSimulations>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/edgegrid-signer-gatling/src/main/scala/com/akamai/edgegrid/signer/gatling/OpenApiSimulation.scala
+++ b/edgegrid-signer-gatling/src/main/scala/com/akamai/edgegrid/signer/gatling/OpenApiSimulation.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.akamai.edgegrid.signer.gatling
+
+import com.akamai.edgegrid.signer.ClientCredential
+import com.akamai.edgegrid.signer.ahc.AsyncHttpClientEdgeGridSignatureCalculator
+import io.gatling.core.Predef.{Simulation, _}
+import io.gatling.http.Predef.http
+
+abstract class OpenApiSimulation(credential: ClientCredential) extends Simulation {
+
+  val httpConf = http
+      .signatureCalculator(new AsyncHttpClientEdgeGridSignatureCalculator(credential))
+      .baseURL("https://" + credential.getHost)
+
+}

--- a/edgegrid-signer-gatling/src/main/scala/com/akamai/edgegrid/signer/gatling/OpenApiSimulation.scala
+++ b/edgegrid-signer-gatling/src/main/scala/com/akamai/edgegrid/signer/gatling/OpenApiSimulation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 
 package com.akamai.edgegrid.signer.gatling
 

--- a/edgegrid-signer-gatling/src/test/resources/logback-test.xml
+++ b/edgegrid-signer-gatling/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gatling.http.ahc" level="TRACE" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="com.akamai" level="TRACE">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+
+</configuration>

--- a/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation1.scala
+++ b/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation1.scala
@@ -1,0 +1,24 @@
+package com.akamai.edgegrid.signer.gatling
+
+import com.akamai.edgegrid.signer.ahc.AsyncHttpClientEdgeGridSignatureCalculator
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+
+class EdgeGridSignerSimulation1 extends Simulation {
+
+  val httpConf = http
+    .baseURL("http://localhost")
+
+  val testScenario = scenario("Test scenario")
+    .exec(
+      http("fakeRequest")
+        .get("/test")
+        .signatureCalculator(new AsyncHttpClientEdgeGridSignatureCalculator(testdata.testCredential))
+    )
+
+  setUp(
+    testScenario.inject(atOnceUsers(1))
+  ).protocols(httpConf)
+
+}

--- a/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation1.scala
+++ b/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation1.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.akamai.edgegrid.signer.gatling
 
 import com.akamai.edgegrid.signer.ahc.AsyncHttpClientEdgeGridSignatureCalculator

--- a/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation2.scala
+++ b/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation2.scala
@@ -1,0 +1,22 @@
+package com.akamai.edgegrid.signer.gatling
+
+import com.akamai.edgegrid.signer.ahc.AsyncHttpClientEdgeGridSignatureCalculator
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class EdgeGridSignerSimulation2 extends Simulation{
+
+  val httpConf = http
+
+  val testScenario = scenario("Test scenario")
+    .exec(
+      http("fakeRequest")
+        .get("https://" + testdata.testCredential.getHost + "/test")
+        .signatureCalculator(new AsyncHttpClientEdgeGridSignatureCalculator(testdata.testCredential))
+    )
+
+  setUp(
+    testScenario.inject(atOnceUsers(1))
+  ).protocols(httpConf)
+
+}

--- a/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation2.scala
+++ b/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/EdgeGridSignerSimulation2.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.akamai.edgegrid.signer.gatling
 
 import com.akamai.edgegrid.signer.ahc.AsyncHttpClientEdgeGridSignatureCalculator

--- a/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/TestData.scala
+++ b/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/TestData.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.akamai.edgegrid.signer.gatling
+
+import com.akamai.edgegrid.signer.ClientCredential
+
+package object testdata {
+
+  val testCredential = ClientCredential.builder
+    .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+    .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+    .clientSecret("SOMESECRET")
+    .host("localhost:9089").build
+
+}

--- a/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/TestData.scala
+++ b/edgegrid-signer-gatling/src/test/scala/com/akamai/edgegrid/signer/gatling/TestData.scala
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.akamai.edgegrid.signer.gatling
 
 import com.akamai.edgegrid.signer.ClientCredential

--- a/edgegrid-signer-google-http-client/README.md
+++ b/edgegrid-signer-google-http-client/README.md
@@ -10,7 +10,7 @@ Java implementation of Akamai {OPEN} EdgeGrid signing.
 
 ## Description
 
-This library implements [Akamai {OPEN} EdgeGrid Authentication][11] for Java.
+This library implements [Akamai {OPEN} EdgeGrid Authentication][1] for Java.
 This particular module is a binding for the [Google HTTP Client Library for Java][2].
 
 ## Usage with Google HTTP Client Library for Java
@@ -21,7 +21,7 @@ Include the following Maven dependency in your project POM:
 <dependency>
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-google-http-client</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>2.1.1</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/src/main/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridInterceptor.java
+++ b/edgegrid-signer-google-http-client/src/main/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridInterceptor.java
@@ -59,7 +59,7 @@ public class GoogleHttpClientEdgeGridInterceptor implements HttpExecuteIntercept
     @Override
     public void intercept(HttpRequest request) throws IOException {
         try {
-            binding.sign(request);
+            binding.sign(request, request);
         } catch (RequestSigningException e) {
             throw new RuntimeException(e);
         }

--- a/edgegrid-signer-google-http-client/src/main/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridRequestSigner.java
+++ b/edgegrid-signer-google-http-client/src/main/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridRequestSigner.java
@@ -18,6 +18,7 @@ package com.akamai.edgegrid.signer.googlehttpclient;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
 
 import com.akamai.edgegrid.signer.AbstractEdgeGridRequestSigner;
@@ -26,6 +27,7 @@ import com.akamai.edgegrid.signer.ClientCredentialProvider;
 import com.akamai.edgegrid.signer.Request;
 import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
 import com.google.api.client.http.ByteArrayContent;
+import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpContent;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.util.FieldInfo;
@@ -36,7 +38,7 @@ import com.google.api.client.util.Types;
  *
  * @author mgawinec@akamai.com
  */
-public class GoogleHttpClientEdgeGridRequestSigner extends AbstractEdgeGridRequestSigner<HttpRequest> {
+public class GoogleHttpClientEdgeGridRequestSigner extends AbstractEdgeGridRequestSigner<HttpRequest, HttpRequest> {
 
     /**
      * Creates an EdgeGrid request signer using the same {@link ClientCredential} for all requests.
@@ -59,6 +61,11 @@ public class GoogleHttpClientEdgeGridRequestSigner extends AbstractEdgeGridReque
     }
 
     @Override
+    protected URI requestUri(HttpRequest request) {
+        return request.getUrl().toURI();
+    }
+
+    @Override
     protected Request map(HttpRequest request) {
         Request.RequestBuilder builder = Request.builder()
                 .method(request.getRequestMethod())
@@ -76,6 +83,10 @@ public class GoogleHttpClientEdgeGridRequestSigner extends AbstractEdgeGridReque
             }
         }
         return builder.build();
+    }
+
+    public void sign(HttpRequest request) throws RequestSigningException {
+        sign(request, request);
     }
 
     @Override
@@ -111,12 +122,12 @@ public class GoogleHttpClientEdgeGridRequestSigner extends AbstractEdgeGridReque
     }
 
     @Override
-    protected void setHost(HttpRequest request, String host) {
+    protected void setHost(HttpRequest request, String host, URI uri) {
         // NOTE: Header names are lower-cased by the library.
         if (request.getHeaders().containsKey("host")) {
             request.getHeaders().put("host", host);
         }
-        request.getUrl().setHost(host);
+        request.setUrl(new GenericUrl(uri));
     }
 
 }

--- a/edgegrid-signer-google-http-client/src/test/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridRequestSignerTest.java
+++ b/edgegrid-signer-google-http-client/src/test/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridRequestSignerTest.java
@@ -59,7 +59,7 @@ public class GoogleHttpClientEdgeGridRequestSignerTest {
         HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(uri));
 
         GoogleHttpClientEdgeGridRequestSigner googleHttpSigner = new GoogleHttpClientEdgeGridRequestSigner(credential);
-        googleHttpSigner.sign(request);
+        googleHttpSigner.sign(request, request);
 
         assertThat(request.getHeaders().containsKey("host"), is(false));
         assertThat(request.getUrl().getHost(), equalTo("endpoint.net"));
@@ -76,7 +76,7 @@ public class GoogleHttpClientEdgeGridRequestSignerTest {
         request.getHeaders().put("Host", "ignored-hostname.com");
 
         GoogleHttpClientEdgeGridRequestSigner googleHttpSigner = new GoogleHttpClientEdgeGridRequestSigner(credential);
-        googleHttpSigner.sign(request);
+        googleHttpSigner.sign(request, request);
 
         // NOTE: The library lower-cases all header names.
         assertThat(request.getHeaders().containsKey("Host"), is(false));

--- a/edgegrid-signer-rest-assured/README.md
+++ b/edgegrid-signer-rest-assured/README.md
@@ -21,7 +21,7 @@ Include the following Maven dependency in your project POM:
 <dependency>
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-rest-assured</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0</version>
 </dependency>
 ```
 

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>2.1.1</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/src/main/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilter.java
+++ b/edgegrid-signer-rest-assured/src/main/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilter.java
@@ -77,7 +77,7 @@ public class RestAssuredEdgeGridFilter implements Filter {
     @Override
     public Response filter(FilterableRequestSpecification requestSpec, FilterableResponseSpecification responseSpec, FilterContext ctx) {
         try {
-            binding.sign(requestSpec);
+            binding.sign(requestSpec, requestSpec);
         } catch (RequestSigningException e) {
             throw new RuntimeException(e);
         }

--- a/edgegrid-signer-rest-assured/src/test/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilterIntegrationTest.java
+++ b/edgegrid-signer-rest-assured/src/test/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilterIntegrationTest.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.akamai.edgegrid.signer.restassured;
+
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import io.restassured.RestAssured;
+import io.restassured.filter.Filter;
+import io.restassured.filter.FilterContext;
+import io.restassured.response.Response;
+import io.restassured.specification.FilterableRequestSpecification;
+import io.restassured.specification.FilterableResponseSpecification;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+/**
+ * Unit tests for {@link RestAssuredEdgeGridFilterIntegrationTest}.
+ *
+ * @author mgawinec@akamai.com
+ */
+public class RestAssuredEdgeGridFilterIntegrationTest {
+
+    static final String SERVICE_MOCK_HOST = "localhost";
+    static final int SERVICE_MOCK_PORT = 9089;
+    static final String SERVICE_MOCK = SERVICE_MOCK_HOST + ":" + SERVICE_MOCK_PORT;
+
+    ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host(SERVICE_MOCK)
+            .build();
+
+    WireMockServer wireMockServer = new WireMockServer(wireMockConfig().httpsPort(SERVICE_MOCK_PORT));
+
+
+
+    @BeforeClass
+    public void setUp() {
+        wireMockServer.start();
+    }
+
+    @BeforeMethod
+    public void reset() {
+        wireMockServer.resetMappings();
+        wireMockServer.resetRequests();
+    }
+
+    @Test
+    // Due to limitations of REST-assured we cannot sign again followed redirects
+    // https://github.com/akamai-open/AkamaiOPEN-edgegrid-java/issues/21
+    public void cannotSignAgainFollowedRedirects() throws URISyntaxException, IOException {
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "/billing-usage/v1/reportSources/alternative")));
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources/alternative"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+        RestAssured.given()
+                .relaxedHTTPSValidation()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .get("/billing-usage/v1/reportSources")
+                .then().statusCode(200);
+
+        List<LoggedRequest> loggedRequests = wireMockServer.findRequestsMatching(RequestPattern
+                .everything()).getRequests();
+        MatcherAssert.assertThat(loggedRequests.get(0).getHeader("Authorization"),
+                CoreMatchers.equalTo(loggedRequests.get(1).getHeader("Authorization")));
+    }
+
+    @Test
+    public void signEachRequest() throws URISyntaxException, IOException {
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+        RestAssured.given()
+                .relaxedHTTPSValidation()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .get("/billing-usage/v1/reportSources")
+                .then().statusCode(200);
+
+        assertThat(wireMockServer.findAllUnmatchedRequests().size(), CoreMatchers.equalTo(0));
+    }
+
+    @Test
+    public void signEachRequestWithPathParams() throws URISyntaxException, IOException {
+
+        wireMockServer.stubFor(get(urlPathMatching("/config-gtm/v1/domains/.*"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+        RestAssured.given()
+                .relaxedHTTPSValidation()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .get("/config-gtm/v1/domains/{domain}", "storage1.akadns.net")
+                .then().statusCode(200);
+
+        assertThat(wireMockServer.findAllUnmatchedRequests().size(), CoreMatchers.equalTo(0));
+    }
+
+    @Test
+    public void signEachRequestWithPathParamsAndQueryString() throws URISyntaxException,
+            IOException {
+
+        wireMockServer.stubFor(get(urlPathMatching("/config-gtm/v1/domains/.*"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .withQueryParam("param1", equalTo("value1"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+        RestAssured.given()
+                .relaxedHTTPSValidation()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .queryParam("param1", "value1")
+                .get("/config-gtm/v1/domains/{domain}", "storage1.akadns.net")
+                .then().statusCode(200);
+
+        assertThat(wireMockServer.findAllUnmatchedRequests().size(), CoreMatchers.equalTo(0));
+    }
+
+    @Test
+    public void signWithHostHeader() throws URISyntaxException, IOException {
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+        RestAssured.given()
+                .relaxedHTTPSValidation()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .header("Host", "ignored-hostname.com")
+                .get("/billing-usage/v1/reportSources")
+                .then().statusCode(200);
+
+        assertThat(wireMockServer.findAllUnmatchedRequests().size(), CoreMatchers.equalTo(0));
+    }
+
+    @Test
+    public void replacesProvidedHostHeader() throws URISyntaxException, IOException,
+            RequestSigningException {
+
+
+        RestAssured.given()
+                .relaxedHTTPSValidation()
+                .header("Host", "ignored-hostname.com")
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .filter(new Filter() {
+                    @Override
+                    public Response filter(FilterableRequestSpecification requestSpec, FilterableResponseSpecification responseSpec, FilterContext ctx) {
+                        MatcherAssert.assertThat(requestSpec.getHeaders().getList("Host").size(),
+                                CoreMatchers.equalTo(1));
+                        MatcherAssert.assertThat(requestSpec.getHeaders().get("Host").getValue(),
+                                CoreMatchers.equalTo(credential.getHost()));
+
+                        return ctx.next(requestSpec, responseSpec);
+                    }
+                })
+                .get();
+
+
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void dontSignEachRequestWithAbsolutePath() throws URISyntaxException, IOException {
+
+        RestAssured.given()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .get("https://ignored-hostname.com/billing-usage/v1/reportSources")
+                .then().statusCode(200);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void dontSignRequestWithFileContent() throws URISyntaxException, IOException {
+
+        RestAssured.given()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .body(new File("/home/johan/some_large_file.bin"))
+                .post("/billing-usage/v1/reportSources")
+                .then().statusCode(200);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void dontSignRequestWithInputStreamContent() throws URISyntaxException, IOException {
+
+        RestAssured.given()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .body(new ByteArrayInputStream("exampleString".getBytes(StandardCharsets.UTF_8)))
+                .post("/billing-usage/v1/reportSources")
+        .then().statusCode(200);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void dontSignRequestWithMultipartContent() throws URISyntaxException, IOException {
+
+        RestAssured.given()
+                .filter(new RestAssuredEdgeGridFilter(credential))
+                .multiPart("file", new File("/home/johan/some_large_file.bin"))
+                .post("/billing-usage/v1/reportSources")
+                .then().statusCode(200);
+    }
+
+    @AfterClass
+    public void tearDownAll() {
+        wireMockServer.stop();
+    }
+
+}

--- a/edgegrid-signer-rest-assured/src/test/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilterIntegrationTest.java
+++ b/edgegrid-signer-rest-assured/src/test/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilterIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ * Copyright 2018 Akamai Technologies, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,15 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>2.1.1</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <modules>
         <module>edgegrid-signer-core</module>
         <module>edgegrid-signer-rest-assured</module>
         <module>edgegrid-signer-google-http-client</module>
         <module>edgegrid-signer-apache-http-client</module>
+        <module>edgegrid-signer-gatling</module>
+        <module>edgegrid-signer-async-http-client</module>
     </modules>
 
     <packaging>pom</packaging>
@@ -126,6 +128,21 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.asynchttpclient</groupId>
+                <artifactId>async-http-client</artifactId>
+                <version>2.0.39</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-app</artifactId>
+                <version>2.3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gatling.highcharts</groupId>
+                <artifactId>gatling-charts-highcharts</artifactId>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
This includes increasing major version to 3.0.0 because of backward incompatible change in AbstractEdgeGridRequestSigner: changing sign to sign(immutableRequest, mutableRequest) because AHC requires signing procedure to use two requests: original request to extract data and mutable request to update with Authorization header.