### PR TITLE
DXE-3119 Improve control over apache http client's proxy selection process.

### DIFF
--- a/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRoutePlanner.java
+++ b/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRoutePlanner.java
@@ -34,12 +34,20 @@ public class ApacheHttpClientEdgeGridRoutePlanner extends SystemDefaultRoutePlan
     private final ApacheHttpClientEdgeGridRequestSigner binding;
 
     public ApacheHttpClientEdgeGridRoutePlanner(ClientCredential clientCredential) {
-        super(ProxySelector.getDefault());
+        this(clientCredential, ProxySelector.getDefault());
+    }
+
+    public ApacheHttpClientEdgeGridRoutePlanner(ClientCredential clientCredential, ProxySelector proxySelector) {
+        super(proxySelector);
         this.binding = new ApacheHttpClientEdgeGridRequestSigner(clientCredential);
     }
 
     public ApacheHttpClientEdgeGridRoutePlanner(ClientCredentialProvider clientCredentialProvider) {
-        super(ProxySelector.getDefault());
+        this(clientCredentialProvider, ProxySelector.getDefault());
+    }
+
+    public ApacheHttpClientEdgeGridRoutePlanner(ClientCredentialProvider clientCredentialProvider, ProxySelector proxySelector) {
+        super(proxySelector);
         this.binding = new ApacheHttpClientEdgeGridRequestSigner(clientCredentialProvider);
     }
 


### PR DESCRIPTION
### Problem description

Currently ApacheHttpClientEdgeGridRoutePlanner is hardwired to use Java's default proxy selector.
This restricts control over the proxy selection process.

This is particularly troublesome when JVM wide proxy settings are not an option.

### Workarounds

(1) Without this change
the same level of control on the the proxy selection process can only be achieved by replacing ApacheHttpClientEdgeGridRoutePlanner by a class that:
- extends SystemDefaultRoutePlanner,
- exposes the proxySelector (like in this PR),
- duplicates the implementation of determineRoute()
- and finally needs to be placed in package com.akamai.edgegrid.signer.apachehttpclient
(for access to protected
com.akamai.edgegrid.signer.apachehttpclient.ApacheHttpClientEdgeGridRequestSigner#map)

(2) In another scenario it would be sufficient to set a RequestConfig with a HttpRequestBase instance 
as demonstrated by [this example](https://github.com/apache/httpcomponents-client/blob/4.5.x/httpclient/src/examples/org/apache/http/examples/client/ClientExecuteProxy.java).
As we are using the JBoss Resteasy framework - that (to my knowledge) does not expose such direct access - this is not an option.


### Implementation note

Additional constructors are required because
ApacheHttpClientEdgeGridRoutePlanner cannot be externally extended
as SystemDefaultRoutePlanner's proxySelector has "private final" modifiers.