### PR TITLE
DXE-3381 Release/5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 5.1.1 (December 6, 2023)
+
+### Fixes
+
+* Fixes for various CVE vulnerabilities by upgrading logback classic, netty and dependency-check.
+
+
 ## 5.1.0 (September 5, 2023)
 
 ### Improvements

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-SNAPSHOT</version>
+        <version>5.1.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.1-rc.1</version>
+        <version>5.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>5.1.0</version>
+        <version>5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>5.1.1-SNAPSHOT</version>
+    <version>5.1.1-rc.1</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <slf4j.version>1.7.36</slf4j.version>
-        <netty.version>4.1.97.Final</netty.version>
-        <logback.version>1.2.11</logback.version>
+        <netty.version>4.1.101.Final</netty.version>
+        <logback.version>1.4.14</logback.version>
         <dependency-check.version>8.4.0</dependency-check.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>5.1.1-rc.1</version>
+    <version>5.1.1</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>5.1.0</version>
+    <version>5.1.1-SNAPSHOT</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>


### PR DESCRIPTION
## 5.1.1 (December 6, 2023)

### Fixes

* Fixes for various CVE vulnerabilities by upgrading logback classic, netty and dependency-check.