### PR TITLE
DXE-4485 Release/6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Change log
 
+## 6.0.1 (December 17, 2024)
+
+### Fixes
+
+* Fixed vulnerability by upgrading the `asynchttpclient` module to 3.0.1 .
+* Removed checks in the `AsyncHttpClientEdgeGridRequestSigner` class for the `ReactiveStreamsBodyGenerator` case, which is no longer available in a new version of the `asynchttpclient` module.
+* Fixed some build errors by upgrading the JaCoCo library.
+
 ## 6.0.0 (August 21, 2024)
 
 ### BREAKING CHANGES
 
-* Replaced deprecated `ApacheHttpTransport` with `com.google.api.client.http.apache.v2.ApacheHttpTransport` in `edgegrid-signer-google-http-client`.
-* Updated `README.md` for `edgegrid-signer-google-http-client` to include changes in the instructions for signing HTTP requests with specified client credentials.
+* Replaced the deprecated `ApacheHttpTransport` method with `com.google.api.client.http.apache.v2.ApacheHttpTransport` in the `edgegrid-signer-google-http-client` module.
+* Updated the `README.md` file for the `edgegrid-signer-google-http-client` module to include changes in the instructions for signing HTTP requests with specified client credentials.
 
 ### Improvements
 
-* Add support for `ProxySelector` in `ApacheHttpClientEdgeGridRoutePlanner` to enable the use of custom proxy servers.
+* Added support for `ProxySelector` in the `ApacheHttpClientEdgeGridRoutePlanner` method to enable the use of custom proxy servers.
 
 ### Fixes
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSigner.java
+++ b/edgegrid-signer-async-http-client/src/main/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridRequestSigner.java
@@ -26,7 +26,6 @@ import org.asynchttpclient.Request;
 import org.asynchttpclient.RequestBuilderBase;
 import org.asynchttpclient.request.body.generator.FileBodyGenerator;
 import org.asynchttpclient.request.body.generator.InputStreamBodyGenerator;
-import org.asynchttpclient.request.body.generator.ReactiveStreamsBodyGenerator;
 import org.asynchttpclient.uri.Uri;
 
 import java.net.URI;
@@ -112,8 +111,6 @@ public class AsyncHttpClientEdgeGridRequestSigner extends AbstractEdgeGridReques
             throw new UnsupportedOperationException("Serializing FileBodyGenerator in request body is not supported");
         } else if (request.getBodyGenerator() instanceof InputStreamBodyGenerator) {
             throw new UnsupportedOperationException("Serializing InputStreamBodyGenerator in request body is not supported");
-        } else if (request.getBodyGenerator() instanceof ReactiveStreamsBodyGenerator) {
-            throw new UnsupportedOperationException("Serializing ReactiveStreamsBodyGenerator in request body is not supported");
         } else if (request.getBodyGenerator() != null) {
             throw new UnsupportedOperationException("Serializing generic BodyGenerator in request body is not supported");
         } else {

--- a/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculatorTest.java
+++ b/edgegrid-signer-async-http-client/src/test/java/com/akamai/edgegrid/signer/ahc/AsyncHttpClientEdgeGridSignatureCalculatorTest.java
@@ -43,7 +43,7 @@ public class AsyncHttpClientEdgeGridSignatureCalculatorTest {
             .host("endpoint.net")
             .build();
 
-        RequestBuilder requestToUpdate = new RequestBuilder(request);
+        RequestBuilder requestToUpdate = new RequestBuilder(request.toString());
         new AsyncHttpClientEdgeGridSignatureCalculator(credential).calculateAndAddSignature(
             request, requestToUpdate);
         Request updatedRequest = requestToUpdate.build();
@@ -65,7 +65,7 @@ public class AsyncHttpClientEdgeGridSignatureCalculatorTest {
             .build();
 
         Request request = new RequestBuilder().setUrl("http://localhost/test?x=y").build();
-        RequestBuilder requestToUpdate = new RequestBuilder(request);
+        RequestBuilder requestToUpdate = new RequestBuilder(request.toString());
 
         new AsyncHttpClientEdgeGridSignatureCalculator(credential).calculateAndAddSignature(
             request, requestToUpdate);
@@ -86,7 +86,7 @@ public class AsyncHttpClientEdgeGridSignatureCalculatorTest {
             .build();
 
         Request request = new RequestBuilder().setUrl("http://localhost/test").addQueryParam("x", "y").build();
-        RequestBuilder requestToUpdate = new RequestBuilder(request);
+        RequestBuilder requestToUpdate = new RequestBuilder(request.toString());
 
         new AsyncHttpClientEdgeGridSignatureCalculator(credential).calculateAndAddSignature(
             request, requestToUpdate);

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.0</version>
+        <version>6.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-rc.1</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.1-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>6.0.1-rc.1</version>
+    <version>6.0.1</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1-SNAPSHOT</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
             <dependency>
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>2.12.3</version>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -200,7 +200,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.10</version>
+                    <version>0.8.12</version>
                     <executions>
                         <execution>
                             <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.1-rc.1</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>


### PR DESCRIPTION
## 6.0.1 (December 17, 2024)

### Fixes

* Fixed vulnerability by upgrading the `asynchttpclient` module to 3.0.1 .
* Removed checks in the `AsyncHttpClientEdgeGridRequestSigner` class for the `ReactiveStreamsBodyGenerator` case, which is no longer available in a new version of the `asynchttpclient` module.
* Fixed some build errors by upgrading the JaCoCo library.
