### PR TITLE
DXE-5662 Release/6.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Change log
 
+## 6.0.3 (Sep 29, 2025)
+
+### Fixes
+
+* Fixed a transitive vulnerability by adding the `netty-bom` module with version `4.2.6.Final`.
+* Fixed a transitive vulnerability by adding the `commons-lang3` module with version `3.18.0`.
+* Upgraded `dependency-check` to `12.1.6` to fix the build issue.
+
 ## 6.0.2 (Apr 10, 2025)
 
 ### Fixes
 
 * Fixed a vulnerability by upgrading the `asynchttpclient` module to `3.0.2`.
-* Upgraded `dependency-check` to 12.1.0 to fix the build issue.
+* Upgraded `dependency-check` to `12.1.0` to fix the build issue.
 
 ## 6.0.1 (Dec 17, 2024)
 

--- a/edgegrid-signer-apache-http-client/README.md
+++ b/edgegrid-signer-apache-http-client/README.md
@@ -22,13 +22,13 @@ For Apache HTTP Client >= 5.0.0, use the [`edgegrid-signer-apache-http-client5`]
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgerc-reader</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgegrid-signer-apache-http-client</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
     </dependencies>
     ```

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/README.md
+++ b/edgegrid-signer-apache-http-client5/README.md
@@ -20,13 +20,13 @@ This module is a binding for the [Apache HTTP Client library version 5.x](https:
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgerc-reader</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgegrid-signer-apache-http-client5</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
     </dependencies>
     ```

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-apache-http-client5/pom.xml
+++ b/edgegrid-signer-apache-http-client5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/README.md
+++ b/edgegrid-signer-async-http-client/README.md
@@ -20,13 +20,13 @@ This module is a binding for the [Async HTTP Client library](https://github.com/
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgerc-reader</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgegrid-signer-async-http-client</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
     </dependencies>
     ```

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-async-http-client/pom.xml
+++ b/edgegrid-signer-async-http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-core</artifactId>

--- a/edgegrid-signer-google-http-client/README.md
+++ b/edgegrid-signer-google-http-client/README.md
@@ -20,13 +20,13 @@ This module is a binding for the [Google HTTP Client library](https://github.com
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgerc-reader</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgegrid-signer-google-http-client</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
     </dependencies>
     ```

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>

--- a/edgegrid-signer-rest-assured/README.md
+++ b/edgegrid-signer-rest-assured/README.md
@@ -20,13 +20,13 @@ This module is a binding for the [REST-assured library](https://github.com/rest-
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgerc-reader</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
 
         <dependency>
             <groupId>com.akamai.edgegrid</groupId>
             <artifactId>edgegrid-signer-rest-assured</artifactId>
-            <version>6.0.2</version>
+            <version>6.0.3</version>
         </dependency>
     </dependencies>
     ```

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-rc.1</version>
+        <version>6.0.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.3-SNAPSHOT</version>
+        <version>6.0.3-rc.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/edgerc-reader/pom.xml
+++ b/edgerc-reader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>edgegrid-signer-parent</artifactId>
         <groupId>com.akamai.edgegrid</groupId>
-        <version>6.0.2</version>
+        <version>6.0.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>6.0.2</version>
+    <version>6.0.3-SNAPSHOT</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,27 @@
         <maven.compiler.target>11</maven.compiler.target>
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.4.14</logback.version>
-        <dependency-check.version>12.1.0</dependency-check.version>
+        <netty.version>4.2.6.Final</netty.version>
+        <dependency-check.version>12.1.6</dependency-check.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <!--added to resolve transitive dependency vulnerabilities:CVE-2025-55163,CVE-2025-58056,CVE-2025-58057-->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!--added to resolve transitive dependency vulnerabilities:CWE-674-->
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
@@ -135,7 +151,7 @@
             <dependency>
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
-                <version>3.0.2</version>
+                <version>3.0.3</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,15 @@
             <organization>Akamai</organization>
             <organizationUrl>https://www.akamai.com</organizationUrl>
         </developer>
+        <developer>
+            <name>Michał Mazur</name>
+            <id>mimaz</id>
+            <roles>
+                <role>Developer</role>
+            </roles>
+            <organization>Akamai</organization>
+            <organizationUrl>https://www.akamai.com</organizationUrl>
+        </developer>
     </developers>
 
     <scm>
@@ -51,17 +60,6 @@
         <developerConnection>scm:git:ssh://git@github.com:akamai/AkamaiOPEN-edgegrid-java.git</developerConnection>
         <url>https://github.com/akamai/AkamaiOPEN-edgegrid-java/tree/master</url>
     </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -271,13 +269,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.9.0</version>
+                    <extensions>true</extensions>
                     <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <stagingProfileId>21d1e18e25c8e4</stagingProfileId>
+                        <publishingServerId>central</publishingServerId>
                     </configuration>
                 </plugin>
             </plugins>
@@ -336,7 +333,7 @@
 
     <profiles>
         <profile>
-            <id>sonatype-oss-release</id>
+            <id>sonatype-central-release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -354,15 +351,15 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <executions>
                             <execution>
                                 <id>default-deploy</id>
                                 <phase>deploy</phase>
                                 <goals>
-                                    <goal>deploy</goal>
+                                    <goal>publish</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>6.0.3-rc.1</version>
+    <version>6.0.3</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-parent</artifactId>
-    <version>6.0.3-SNAPSHOT</version>
+    <version>6.0.3-rc.1</version>
 
     <modules>
         <module>edgegrid-signer-apache-http-client</module>


### PR DESCRIPTION
## 6.0.3 (Sep 29, 2025)

### Fixes

* Fixed a transitive vulnerability by adding the `netty-bom` module with version `4.2.6.Final`.
* Fixed a transitive vulnerability by adding the `commons-lang3` module with version `3.18.0`.
* Upgraded `dependency-check` to `12.1.6` to fix the build issue.